### PR TITLE
Fix GitHub Pages base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Ce projet utilise **Vite** et **React** pour afficher les pages de l'application
 - `npm run preview` lance un serveur local pour prévisualiser la build.
 
 L'installation des dépendances requiert `npm install`.
+
+## Déploiement GitHub Pages
+
+Le fichier `vite.config.js` définit `base: '/Morpho/'` afin que les chemins
+fonctionnent correctement sur GitHub Pages. Après `npm run build`, publiez le
+contenu du dossier `dist` sur votre dépôt pour éviter les erreurs 404.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import './App.css'
 
 function App() {
   return (
-    <Router>
+    <Router basename="/Morpho">
       <header>
         <h1>Morpho</h1>
         <nav>

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/Morpho/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- prefix Router with basename for GitHub Pages
- set base URL in Vite config
- document GitHub Pages deployment

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e78b6fc4832a835443d7f5cf1310