### PR TITLE
Add mission text and ROI chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "morpho",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^3.9.1",
         "react": "^18.2.0",
+        "react-chartjs-2": "^4.3.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1"
       },
@@ -1239,6 +1241,12 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chart.js": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -1929,6 +1937,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-4.3.1.tgz",
+      "integrity": "sha512-5i3mjP6tU7QSn0jvb8I4hudTzHJqS8l00ORJnVwI2sYu0ihpj83Lv2YzfxunfxTZkscKvZu2F2w9LkwNBhj6xA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^3.5.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "chart.js": "^3.9.1",
     "react": "^18.2.0",
+    "react-chartjs-2": "^4.3.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -141,6 +141,13 @@ nav a:hover {
   background-color: #000;
 }
 
+/* Mission & ROI sections */
+#mission,
+#roi {
+  max-width: 800px;
+  margin: 0 auto 40px auto;
+}
+
 /* Footer */
 footer {
   background-color: #f2f2f2;

--- a/src/components/ROIChart.jsx
+++ b/src/components/ROIChart.jsx
@@ -1,0 +1,69 @@
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+const queries = [1, 3, 5, 8, 12];
+
+function generateROIData(cost) {
+  // assume profit per print of 20€
+  return queries.map(q => ((q * 20) - cost) / cost * 100);
+}
+
+const data = {
+  labels: queries.map(q => `${q} requêtes/mois`),
+  datasets: [
+    {
+      label: 'Ender 3',
+      data: generateROIData(200),
+      borderColor: 'rgba(75, 192, 192, 1)',
+      backgroundColor: 'rgba(75, 192, 192, 0.2)',
+    },
+    {
+      label: 'Prusa i3',
+      data: generateROIData(800),
+      borderColor: 'rgba(255, 99, 132, 1)',
+      backgroundColor: 'rgba(255, 99, 132, 0.2)',
+    },
+    {
+      label: 'Ultimaker S5',
+      data: generateROIData(6000),
+      borderColor: 'rgba(54, 162, 235, 1)',
+      backgroundColor: 'rgba(54, 162, 235, 0.2)',
+    },
+  ],
+};
+
+const options = {
+  responsive: true,
+  plugins: {
+    legend: {
+      position: 'bottom',
+    },
+    title: {
+      display: true,
+      text: 'ROI estimé en fonction du nombre de requêtes',
+    },
+  },
+};
+
+export default function ROIChart() {
+  return <Line data={data} options={options} />;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,6 @@
 
+import ROIChart from '../components/ROIChart'
+
 function Home() {
   return (
     <>
@@ -6,6 +8,17 @@ function Home() {
         <h2>Impression 3D créative &amp; sur mesure</h2>
         <p>Commandez des objets uniques et personnalisés, imprimés localement.</p>
       </div>
+
+      <section className="section" id="mission">
+        <h2>Pourquoi notre mission compte</h2>
+        <p>
+          Morpho met en relation les propriétaires d&rsquo;imprimantes 3D avec les
+          personnes qui souhaitent faire imprimer leurs modèles. Si vous disposez
+          d&rsquo;une imprimante que vous n&rsquo;utilisez pas souvent, c&rsquo;est l&rsquo;occasion de
+          rentabiliser votre matériel en imprimant pour les autres et en
+          expédiant vos créations directement chez eux.
+        </p>
+      </section>
 
       <section className="section" id="produits">
         <div className="grid">
@@ -42,6 +55,10 @@ function Home() {
             </div>
           </div>
         </div>
+      </section>
+
+      <section className="section" id="roi">
+        <ROIChart />
       </section>
 
     </>


### PR DESCRIPTION
## Summary
- explain the mission on the homepage
- include an ROI chart for popular printers
- style mission & chart sections
- add Chart.js dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857fa4080688320927d733f52a01c6e