### PR TITLE
Add TOS page with disclaimer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Home from './pages/Home'
 import DevenirImprimeur from './pages/DevenirImprimeur'
 import Products from './pages/Products'
 import Contact from './pages/Contact'
+import Terms from './pages/Terms'
 import './App.css'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
@@ -16,6 +17,7 @@ function App() {
         <Route path="/products" element={<Products />} />
         <Route path="/devenir-imprimeur" element={<DevenirImprimeur />} />
         <Route path="/contact" element={<Contact />} />
+        <Route path="/tos" element={<Terms />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,10 @@
+import { Link } from 'react-router-dom';
+
 function Footer() {
   return (
     <footer>
-      © 2025 Morpho. Tous droits réservés. | Site par Morpho Design Studio
+      © 2025 Morpho. Tous droits réservés. | Site par Morpho Design Studio |
+      <Link to="/tos" style={{ marginLeft: '0.25rem' }}>TOS</Link>
     </footer>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,7 +4,7 @@ function Footer() {
   return (
     <footer>
       © 2025 Morpho. Tous droits réservés. | Site par Morpho Design Studio |
-      <Link to="/tos" style={{ marginLeft: '0.25rem' }}>TOS</Link>
+<Link to="/tos" style={{ marginLeft: '0.25rem' }}>Conditions d'utilisation</Link>
     </footer>
   );
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,7 +13,6 @@ function Navbar() {
         <Link to="/products">Produits</Link>
         <Link to="/devenir-imprimeur">Imprimeur ?</Link>
         <Link to="/contact">Contact</Link>
-        <Link to="/tos">TOS</Link>
       </nav>
     </header>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,6 +13,7 @@ function Navbar() {
         <Link to="/products">Produits</Link>
         <Link to="/devenir-imprimeur">Imprimeur ?</Link>
         <Link to="/contact">Contact</Link>
+        <Link to="/tos">TOS</Link>
       </nav>
     </header>
   );

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 const GITHUB_URL = "https://github.com/LeaRiglet/Morpho";
 
@@ -28,6 +29,9 @@ export default function Contact() {
       >
         Accéder au GitHub Morpho
       </a>
+      <p style={{ marginTop: "2rem" }}>
+        <Link to="/tos">Consulter les conditions d'utilisation</Link>
+      </p>
     </div>
   );
 }

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -3,15 +3,15 @@ import React from "react";
 export default function Terms() {
   return (
     <div className="container" style={{ padding: "2rem" }}>
-      <h1>Terms of Service</h1>
+<h1>Conditions d'utilisation</h1>
       <p>
-        This site is a personal side project and prototype. It is not a
-        for-profit product and does not generate any revenue.
+        Ce site est un projet personnel réalisé à titre expérimental et n’a aucune vocation commerciale. Il ne génère aucun revenu et n’est pas destiné à un usage professionnel.
       </p>
       <p>
-        All information provided here is offered without any guarantee of
-        accuracy or completeness. As this is an experimental prototype, nothing
-        on this site should be considered final or authoritative.
+        Les informations présentées sur ce site sont fournies à titre indicatif, sans garantie quant à leur exactitude ou leur exhaustivité. En tant que prototype, le contenu peut évoluer à tout moment et ne doit pas être considéré comme définitif ou officiel.
+      </p>
+      <p>
+        En utilisant ce site, vous reconnaissez qu’il s’agit d’une plateforme expérimentale et acceptez que son contenu soit susceptible de comporter des erreurs ou des imprécisions. Aucune responsabilité ne pourra être engagée concernant l’utilisation des informations proposées.
       </p>
     </div>
   );

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function Terms() {
+  return (
+    <div className="container" style={{ padding: "2rem" }}>
+      <h1>Terms of Service</h1>
+      <p>
+        This site is a personal side project and prototype. It is not a
+        for-profit product and does not generate any revenue.
+      </p>
+      <p>
+        All information provided here is offered without any guarantee of
+        accuracy or completeness. As this is an experimental prototype, nothing
+        on this site should be considered final or authoritative.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Terms of Service page with prototype disclaimer
- link to TOS from navbar
- wire Terms page into router

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857fa73d89483209d1ca6b04afe3230