### PR TITLE
Trigger ROI chart on scroll

### DIFF
--- a/src/components/ROIChart.jsx
+++ b/src/components/ROIChart.jsx
@@ -1,4 +1,5 @@
 import { Line } from 'react-chartjs-2';
+import { useEffect, useRef, useState } from 'react';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -87,9 +88,33 @@ const options = {
 };
 
 export default function ROIChart() {
+  const containerRef = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.3 }
+    );
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div style={{ width: "100%", maxWidth: 1000, margin: "0 auto", height: 400 }}>
-      <Line data={data} options={options} height={400} width={1000} />
+    <div
+      ref={containerRef}
+      style={{ width: "100%", maxWidth: 1000, margin: "0 auto", height: 400 }}
+    >
+      {visible && <Line data={data} options={options} height={400} width={1000} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- start ROI line chart animation only when the chart scrolls into view

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685800ad79c08320bce88b7033a3ae62