### PR TITLE
Add confetti animation on add-to-cart buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "morpho",
       "version": "0.0.0",
       "dependencies": {
+        "canvas-confetti": "^1.9.3",
         "chart.js": "^3.9.1",
         "react": "^18.2.0",
         "react-chartjs-2": "^4.3.1",
@@ -1240,6 +1241,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chart.js": {
       "version": "3.9.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.3",
     "chart.js": "^3.9.1",
     "react": "^18.2.0",
     "react-chartjs-2": "^4.3.1",

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,18 @@
 
 import ROIChart from '../components/ROIChart'
+import confetti from 'canvas-confetti'
+
+function triggerConfetti(event) {
+  const rect = event.currentTarget.getBoundingClientRect()
+  confetti({
+    particleCount: 80,
+    spread: 70,
+    origin: {
+      x: (rect.left + rect.width / 2) / window.innerWidth,
+      y: (rect.top + rect.height / 2) / window.innerHeight,
+    },
+  })
+}
 
 function Home() {
   return (
@@ -18,7 +31,7 @@ function Home() {
             <div className="card-content">
               <h3>Support de téléphone</h3>
               <p>12€</p>
-              <button>Ajouter au panier</button>
+              <button onClick={triggerConfetti}>Ajouter au panier</button>
             </div>
           </div>
 
@@ -29,7 +42,7 @@ function Home() {
             <div className="card-content">
               <h3>Boîte à bijoux</h3>
               <p>18€</p>
-              <button>Ajouter au panier</button>
+              <button onClick={triggerConfetti}>Ajouter au panier</button>
             </div>
           </div>
 
@@ -40,7 +53,7 @@ function Home() {
             <div className="card-content">
               <h3>Porte-clés personnalisable</h3>
               <p>5€</p>
-              <button>Ajouter au panier</button>
+              <button onClick={triggerConfetti}>Ajouter au panier</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `canvas-confetti` dependency
- trigger confetti when clicking `Ajouter au panier` buttons

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685800d5a24c8320a2bd019076e11ce0