### PR TITLE
Apply neumorphism styling

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 function Footer() {
   return (
-    <footer className="bg-gray-100 text-center py-8 text-gray-600 text-sm mt-auto w-full">
+    <footer className="bg-gray-200 text-center py-8 text-gray-600 text-sm mt-auto w-full shadow-inner-neumorphism">
       © 2025 Morpho. Tous droits réservés. | Site par Morpho Design Studio |
       <Link className="ml-1 underline" to="/tos">Conditions d'utilisation</Link>
     </footer>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 function Navbar() {
   return (
-<header className="sticky top-0 z-50 bg-gray-900 text-white px-8 py-5 flex justify-between items-center">
+<header className="sticky top-0 z-50 bg-gray-200 text-gray-700 px-8 py-5 flex justify-between items-center shadow-neumorphism">
       <h1 className="text-xl tracking-wide font-semibold">
         <Link to="/" className="text-inherit no-underline">
           Morpho

--- a/src/components/ROIChart.jsx
+++ b/src/components/ROIChart.jsx
@@ -112,7 +112,7 @@ export default function ROIChart() {
   return (
     <div
       ref={containerRef}
-      className="w-full max-w-[1000px] mx-auto h-[400px]"
+      className="w-full max-w-[1000px] mx-auto h-[400px] rounded-3xl bg-gray-200 shadow-neumorphism p-6"
     >
       {visible && (
         <Line data={data} options={options} height={400} width={1000} />

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@
 
 /* Neumorphism styles */
 
+body {
+  background: #e0e0e0;
+  color: #333;
+  font-family: 'Inter', sans-serif;
+}
+
 .shadow-neumorphism {
   box-shadow:
     8px 8px 15px #bebebe,

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -5,7 +5,7 @@ const GITHUB_URL = "https://github.com/LeaRiglet/Morpho";
 
 export default function Contact() {
   return (
-    <div className="max-w-xl mx-auto my-8 p-8 bg-gray-50 rounded shadow">
+    <div className="max-w-xl mx-auto my-8 p-8 bg-gray-200 rounded-3xl shadow-neumorphism">
       <h2 className="text-2xl font-bold mb-4">Contactez-nous</h2>
       <p>
         Pour toute question, suggestion ou demande de collaboration, n'hésitez pas à nous contacter via notre page GitHub principale :
@@ -14,7 +14,7 @@ export default function Contact() {
         href={GITHUB_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-block mt-6 px-4 py-3 bg-gray-900 text-white rounded font-bold text-lg shadow"
+        className="inline-block mt-6 px-4 py-3 bg-gray-200 text-gray-700 rounded-3xl font-bold text-lg shadow-neumorphism-btn hover:shadow-neumorphism-btn-hover"
       >
         Accéder au GitHub Morpho
       </a>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -17,56 +17,56 @@ function triggerConfetti(event) {
 function Home() {
   return (
     <>
-      <div className="bg-gradient-to-br from-blue-100 to-blue-50 py-16 text-center">
+      <div className="bg-gray-200 shadow-neumorphism py-16 text-center rounded-3xl mx-4">
         <h2 className="text-4xl font-bold mb-2">Impression 3D créative &amp; sur mesure</h2>
         <p className="text-lg text-gray-600">Commandez des objets uniques et personnalisés, imprimés localement.</p>
       </div>
 
       <section className="py-10 max-w-6xl mx-auto" id="produits">
         <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
-          <div className="rounded-xl shadow-md overflow-hidden bg-gray-50 flex flex-col">
+          <div className="rounded-3xl shadow-neumorphism overflow-hidden bg-gray-200 flex flex-col p-4">
             <div className="aspect-square w-full overflow-hidden">
               <img src="/Morpho/3d_printed_phone_support.png" alt="Support de téléphone" className="object-cover w-full h-full" />
             </div>
             <div className="p-4 flex flex-col flex-1">
               <h3 className="text-lg font-semibold mb-2">Support de téléphone</h3>
               <p className="mb-4 text-gray-600">12€</p>
-              <button onClick={triggerConfetti} className="mt-auto px-4 py-2 rounded bg-gray-800 text-white font-semibold hover:bg-black">Ajouter au panier</button>
+              <button onClick={triggerConfetti} className="mt-auto px-4 py-2 rounded-3xl bg-gray-200 text-gray-700 font-semibold shadow-neumorphism-btn hover:shadow-neumorphism-btn-hover">Ajouter au panier</button>
             </div>
           </div>
 
-          <div className="rounded-xl shadow-md overflow-hidden bg-gray-50 flex flex-col">
+          <div className="rounded-3xl shadow-neumorphism overflow-hidden bg-gray-200 flex flex-col p-4">
             <div className="aspect-square w-full overflow-hidden">
               <img src="/Morpho/3d_printed_lockbox.png" alt="Boîte à bijoux" className="object-cover w-full h-full" />
             </div>
             <div className="p-4 flex flex-col flex-1">
               <h3 className="text-lg font-semibold mb-2">Boîte à bijoux</h3>
               <p className="mb-4 text-gray-600">18€</p>
-              <button onClick={triggerConfetti} className="mt-auto px-4 py-2 rounded bg-gray-800 text-white font-semibold hover:bg-black">Ajouter au panier</button>
+              <button onClick={triggerConfetti} className="mt-auto px-4 py-2 rounded-3xl bg-gray-200 text-gray-700 font-semibold shadow-neumorphism-btn hover:shadow-neumorphism-btn-hover">Ajouter au panier</button>
             </div>
           </div>
 
-          <div className="rounded-xl shadow-md overflow-hidden bg-gray-50 flex flex-col">
+          <div className="rounded-3xl shadow-neumorphism overflow-hidden bg-gray-200 flex flex-col p-4">
             <div className="aspect-square w-full overflow-hidden">
               <img src="/Morpho/3d_printed_key_ring.png" alt="Porte-clés personnalisable" className="object-cover w-full h-full" />
             </div>
             <div className="p-4 flex flex-col flex-1">
               <h3 className="text-lg font-semibold mb-2">Porte-clés personnalisable</h3>
               <p className="mb-4 text-gray-600">5€</p>
-              <button onClick={triggerConfetti} className="mt-auto px-4 py-2 rounded bg-gray-800 text-white font-semibold hover:bg-black">Ajouter au panier</button>
+              <button onClick={triggerConfetti} className="mt-auto px-4 py-2 rounded-3xl bg-gray-200 text-gray-700 font-semibold shadow-neumorphism-btn hover:shadow-neumorphism-btn-hover">Ajouter au panier</button>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="py-10 max-w-2xl mx-auto" id="mission">
+      <section className="py-10 max-w-2xl mx-auto bg-gray-200 shadow-neumorphism rounded-3xl px-6" id="mission">
         <h2 className="text-2xl font-bold mb-4 text-center">Pourquoi notre mission compte</h2>
         <p className="text-gray-700">
           Morpho met en relation les propriétaires d&rsquo;imprimantes 3D avec les personnes qui souhaitent faire imprimer leurs modèles. Si vous disposez d&rsquo;une imprimante que vous n&rsquo;utilisez pas souvent, c&rsquo;est l&rsquo;occasion de rentabiliser votre matériel en imprimant pour les autres et en expédiant vos créations directement chez eux.
         </p>
       </section>
 
-      <section className="py-10" id="roi">
+      <section className="py-10 mx-4" id="roi">
         <ROIChart />
       </section>
 

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -29,7 +29,7 @@ const products = [
 
 function Products() {
   return (
-    <main className="max-w-5xl mx-auto mt-10 p-6 rounded-lg">
+    <main className="max-w-5xl mx-auto mt-10 p-6 rounded-3xl bg-gray-200 shadow-neumorphism">
       <h2 className="text-3xl font-bold mb-2 text-center text-indigo-900">Nos Produits</h2>
       <p className="text-center text-gray-600 mb-10">
         Découvrez notre sélection d’objets imprimés en 3D, conçus pour allier utilité et originalité.
@@ -37,10 +37,10 @@ function Products() {
       <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
         {products.map((product, idx) => (
           <div
-            className="bg-white rounded-xl shadow-md p-6 flex flex-col items-center border transition-transform hover:-translate-y-1 hover:shadow-lg"
+            className="bg-gray-200 rounded-3xl shadow-neumorphism p-6 flex flex-col items-center transition-transform hover:-translate-y-1"
             key={idx}
           >
-            <img src={product.image} alt={product.title} className="w-32 h-32 object-contain mb-4 rounded-lg bg-gray-100 shadow" />
+            <img src={product.image} alt={product.title} className="w-32 h-32 object-contain mb-4 rounded-xl bg-gray-200 shadow-neumorphism" />
             <h3 className="text-lg font-semibold mb-1 text-center">{product.title}</h3>
             <p className="text-gray-600 text-center mb-2">{product.description}</p>
             <div className="font-bold text-blue-600">{product.price}</div>

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Terms() {
   return (
-    <div className="container mx-auto max-w-3xl p-8">
+    <div className="container mx-auto max-w-3xl p-8 bg-gray-200 rounded-3xl shadow-neumorphism">
       <h1 className="text-2xl font-bold mb-4">Conditions d'utilisation</h1>
       <p>
         Ce site est un projet personnel réalisé à titre expérimental et n’a aucune vocation commerciale. Il ne génère aucun revenu et n’est pas destiné à un usage professionnel.


### PR DESCRIPTION
## Summary
- switch base colors to a light gray background
- give Navbar and Footer soft shadows
- restyle cards and buttons across pages using neumorphism
- wrap terms and contact blocks in neuromorphic containers
- adjust ROI chart container appearance

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68585cc3f1b4832096da1b04c5819e5a